### PR TITLE
Fix viewport issues on the “avoid FOLRI” demo

### DIFF
--- a/demos/no-folri/index.html
+++ b/demos/no-folri/index.html
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <title>No FOLRI Demo</title>
 <meta name="description" content="Our goal is a markup-based means of delivering alternate image sources based on device capabilities.">
-<meta name="author" content ="Agustin Amenabar, contact: baamenabar@gmail.com">
+<meta name="author" content ="Agustin Amenabar L., contact: baamenabar@gmail.com">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">
 <meta property="og:type" content="website">
@@ -92,7 +92,7 @@
 
     <section>
         <h2>Credits</h2>
-        <p><em>Author: <a href="http://code.medula.cl">Agustín Amenabar</a> / <a href="https://twitter.com/ImINaBAR">@ImINaBAR</a></em></p>
+        <p><em>Author: <a href="http://code.medula.cl">Agustín Amenabar L.</a> / <a href="https://twitter.com/ImINaBAR">@ImINaBAR</a></em></p>
     </section>
 	</div>
 </div>


### PR DESCRIPTION
There where some CSS issues that where making a mess of the layout on small devices. Updated the template to the current one with links to the current stylesheets now. It worked on local testing.
