### PR TITLE
Expand the range of solutions the RICG can explore

### DIFF
--- a/demos/art-direction/index.html
+++ b/demos/art-direction/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="utf-8">
 <title>Art direction Demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Shane Hudson, contact: mail@shanehudson.net">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/demos/basic-implementation/index.html
+++ b/demos/basic-implementation/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="utf-8">
 <title>Simple crop demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Anselm Hannemann, contact: info@anselm-hannemann.com">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/demos/no-folri/index.html
+++ b/demos/no-folri/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="utf-8">
 <title>No FOLRI Demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Agustin Amenabar L., contact: baamenabar@gmail.com">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/demos/on-a-grid/index.html
+++ b/demos/on-a-grid/index.html
@@ -7,7 +7,7 @@
 
 <meta charset="utf-8">
 <title>Grid system demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Andreas Klein, contact: mail@andreasklein.org">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/demos/orientation/index.html
+++ b/demos/orientation/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="utf-8">
 <title>Orientation Demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Andreas Klein, contact: mail@andreasklein.org">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/demos/print/index.html
+++ b/demos/print/index.html
@@ -6,7 +6,7 @@
 <head>
 <meta charset="utf-8">
 <title>Print Demo</title>
-<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 <meta name="author" content ="Brian Muenzenmeyer, contact: brian.muenzenmeyer@gmail.com">
 <meta property="og:url" content="http://responsiveimages.org">
 <meta property="og:site_name" content="Responsive Images Community Group">

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>ResponsiveImages.org</title>
-	<meta name="description" content="Our goal is a client-side solution of delivering alternate image data based on device capabilities.">
+	<meta name="description" content="Our goal is a client-side solution for delivering alternate image data based on device capabilities.">
 	<meta property="og:url" content="http://responsiveimages.org">
 	<meta property="og:site_name" content="Responsive Images Community Group">
 	<meta property="og:type" content="website">
@@ -19,7 +19,7 @@
 	<header class="doc-head">
 		<div class="col-a">
 			<h1 class="logo"><img src="img/logo.png" alt="Responsive Images Community Group logo"></h1>
-			<p class="intro">We’re a group of developers working towards a client-side solution of delivering alternate image data based on device capabilities to prevent wasted bandwidth and optimize display for both screen and print. </p>
+			<p class="intro">We’re a group of developers working towards a client-side solution for delivering alternate image data based on device capabilities to prevent wasted bandwidth and optimize display for both screen and print. </p>
 			<a href="http://www.w3.org/community/respimg/" class="subhed go">Join Us!</a>
 		</div>
 		<figure class="col-b live-demo">


### PR DESCRIPTION
Current description of the community group includes the words "markup-based" which limit the range of solutions the group can explore. I've modified it to "client-side" to expand that range, while maintaining the original intention of finding a solution that doesn't depend on expensive and complicated server-side.
