### PR TITLE
Update specification URLs on home page

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,9 +61,9 @@
 			</section>
 
 			<section class="col-two topic">
-				<h1 class="subhed"><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content.html#the-picture-element">What are the `srcset` and `sizes` attributes?</a></h1>
+				<h1 class="subhed"><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset">What are the `srcset` and `sizes` attributes?</a></h1>
 				<p>The <code>srcset</code> and <code>sizes</code> attributes extend the <code>img</code> and <code>source</code> elements to provide a list of available image sources and their sizes. Browsers can then use this information to pick the best image source.</p>
-				<p>Both <code>srcset</code> and <code>sizes</code> are part of the <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content.html#the-picture-element">HTML specification</a> and can used separately or in conjunction with the <code>picture</code> element.</p>
+				<p>Both <code>srcset</code> and <code>sizes</code> are part of the <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset">HTML specification</a> and can used separately or in conjunction with the <code>picture</code> element.</p>
 
 				<figure class="snippet">
 					<figcaption class="codehed">Sample Markup for `srcset` and `sizes`</figcaption>

--- a/index.php
+++ b/index.php
@@ -38,11 +38,11 @@
 	<div class="main">
 		<div>
 			<section class="col-two topic">
-				<h1 class="subhed"><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content.html#the-picture-element">What is the `picture` Element?</a></h1>
+				<h1 class="subhed"><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">What is the `picture` Element?</a></h1>
 				<p>The <code>picture</code> element is a markup pattern that allows developers to declare multiple sources for
 				an image. By using media queries, it gives developers control as to when and if those
 				images are presented to the user.</p>
-				<p>The <code>picture</code> element is one part of the  <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content.html#the-picture-element">HTML specification</a>.</p>
+				<p>The <code>picture</code> element is one part of the  <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">HTML specification</a>.</p>
 
 			  <figure class="snippet">
 					<figcaption class="codehed">Sample Markup for `picture`</figcaption>


### PR DESCRIPTION
Two minor changes to the home page

* whatwg have changed the URL for the spec, point `picture` link to new address
* fix `srcset` link to point to the correct section of the spec.